### PR TITLE
build: Define script que combina os comandos de build e deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "deploy": "npm run build && surge ./build --domain aceleradev.surge.sh"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Para realizar um deploy, execute o comando **_npm run deploy_** no terminal.
Este comando irá construir a aplicação e, em seguida, publicá-la no domínio configurado, tudo em uma única etapa.